### PR TITLE
Add support for order items with no product ID

### DIFF
--- a/src/Service/Easy/CheckoutService.php
+++ b/src/Service/Easy/CheckoutService.php
@@ -351,7 +351,7 @@ class CheckoutService
                 $netAmount = round($quantity * $unitPrice);
 
                 $items[] = [
-                    'reference' => $item->getProductId(),
+                    'reference' => $item->getProductId() ?? $item->getId(),
                     'name' => $this->stringFilter($item->getLabel()),
                     'quantity' => $quantity,
                     'unit' => 'pcs',


### PR DESCRIPTION
Items which is not of the "product" type (credit, custom etc.) do not have a product ID, and if these are present when ordering, it will cause an error of missing reference. This change will add a fallback to item ID in this case.